### PR TITLE
Fix virt7 repository link/name

### DIFF
--- a/centos-atomic-base.json
+++ b/centos-atomic-base.json
@@ -5,7 +5,7 @@
     "ref": "centos/7/atomic/x86_64/base",
     
     "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
-              "atomic7-testing", "virt7-testing"],
+              "atomic7-testing"],
 
     "selinux": true,
 

--- a/virt7-testing.repo
+++ b/virt7-testing.repo
@@ -1,5 +1,0 @@
-[virt7-testing]
-name=virt7-testing
-baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
-gpgcheck=0
-exclude=kernel docker


### PR DESCRIPTION
virt7-testing has been split into several repos. virt7-common-testing
should be used instead.

See cbs.centos.org/repos/ for an up-to-date list of available repos.
